### PR TITLE
Add new sirius-desktop repo

### DIFF
--- a/otterdog/eclipse-sirius.jsonnet
+++ b/otterdog/eclipse-sirius.jsonnet
@@ -64,12 +64,11 @@ orgs.newOrg('eclipse-sirius') {
       allow_merge_commit: false,
       allow_squash_merge: false,
       default_branch: "master",
-      description: "Sirius Desktop: desktop-based graphical modelers for dedicated DSLs (sample application)",
-      homepage: "https://www.eclipse.org/sirius/getstarted.html",
+      description: "Sirius Desktop: desktop-based graphical modelers for dedicated DSLs",
+      homepage: "https://www.eclipse.org/sirius/",
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master') {
           required_approving_review_count: 1,
-          required_status_checks: [],
           requires_linear_history: true,
           requires_strict_status_checks: true,
         },

--- a/otterdog/eclipse-sirius.jsonnet
+++ b/otterdog/eclipse-sirius.jsonnet
@@ -60,6 +60,21 @@ orgs.newOrg('eclipse-sirius') {
         },
       ],
     },
+    orgs.newRepo('sirius-desktop') {
+      allow_merge_commit: false,
+      allow_squash_merge: false,
+      default_branch: "master",
+      description: "Sirius Desktop: desktop-based graphical modelers for dedicated DSLs (sample application)",
+      homepage: "https://www.eclipse.org/sirius/getstarted.html",
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('master') {
+          required_approving_review_count: 1,
+          required_status_checks: [],
+          requires_linear_history: true,
+          requires_strict_status_checks: true,
+        },
+      ],
+    },
     orgs.newRepo('sirius-emf-json') {
       allow_merge_commit: false,
       allow_squash_merge: false,


### PR DESCRIPTION
This PR adds a new repo sirius-desktop as requested here: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3333

As requested the following settings are disabled:

* allow_merge_commit
* allow_squash_merge

A similar branch protection rule as already present for sirius-web has been added as well.
Keep in mind that the setting *required_status_checks* is explicitly set to [] as it reflect the current status, if this setting would be removed, the default value would be inherited which would add the eclipsefdn eca validation check as mandatory status check to pass before accepting a PR.

That means that the eca check is currently not enforced, but if you would like to enforce it (suggested), we can adapt the configuration to include these checks as mandatory.
