### PR TITLE
Remove the `required_approving_review_count`

### DIFF
--- a/otterdog/eclipse-sirius.jsonnet
+++ b/otterdog/eclipse-sirius.jsonnet
@@ -77,7 +77,7 @@ orgs.newOrg('eclipse-sirius') {
       homepage: "https://www.eclipse.org/sirius/",
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
           requires_linear_history: true,
           requires_strict_status_checks: true,
         },


### PR DESCRIPTION
We sometimes need to push changes quickly without waiting for a review from another commiter.

We trust our commiters not to abuse this power.