### PR TITLE
Remove the old sirius-web repo

### DIFF
--- a/otterdog/eclipse-sirius.jsonnet
+++ b/otterdog/eclipse-sirius.jsonnet
@@ -107,24 +107,6 @@ orgs.newOrg('eclipse-sirius') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
-    orgs.newRepo('sirius-web') {
-      allow_update_branch: false,
-      default_branch: "master",
-      dependabot_alerts_enabled: false,
-      description: "Sirius Web: cloud-based graphical modelers for dedicated DSLs (sample application)",
-      homepage: "https://www.eclipse.org/sirius/sirius-web.html",
-      secret_scanning: "disabled",
-      secret_scanning_push_protection: "disabled",
-      web_commit_signoff_required: false,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: 1,
-          required_status_checks: [],
-          requires_linear_history: true,
-          requires_strict_status_checks: true,
-        },
-      ],
-    },
     orgs.newRepo('sirius-website') {
       allow_merge_commit: false,
       allow_squash_merge: false,


### PR DESCRIPTION
We currently have two separate GitHub repos for the web version of Eclipse Sirius https://github.com/eclipse-sirius/sirius-components and https://github.com/eclipse-sirius/sirius-web. Initialy the split was to separate the "framework" part (sirius-components) from the "default application" part (sirius-web).

In practice this has caused more overhead than it's worth, and in the last few months we have re-integrated the code for the "default application" in sirius-components where 99% of the code lives. sirius-components is now self-contained and is where the actual development occur.

We would like to:

- delete the current eclipse-sirius/sirius-web repo, which is now an empty shell (this PR);
- rename the eclipse-sirius/sirius-components, where the actual development occurs into eclipse-sirius/sirius-web (upcoming PR from [this commit](https://github.com/pcdavid/.eclipsefdn/commit/b0b1ccbf9cff084a5c3135e7fc7d953e25791ecc)).

We split this in two separate steps as we will reuse the `sirius-web` name, and I don't think the two operations can be described in a single Otterdog configuration change.
