### PR TITLE
Add GH_ACTION_TOKEN secret

### DIFF
--- a/otterdog/eclipse-sirius.jsonnet
+++ b/otterdog/eclipse-sirius.jsonnet
@@ -127,6 +127,11 @@ orgs.newOrg('eclipse-sirius') {
       workflows+: {
         default_workflow_permissions: "write",
       },
+      secrets: [
+        orgs.newRepoSecret('GH_ACTION_TOKEN') {
+          value: "pass:bots/modeling.sirius/github.com/api-token",
+        },
+      ],
     },
     orgs.newRepo('.github') {
       allow_merge_commit: true,


### PR DESCRIPTION
Needed for the GitHub Actions workflow in sirius-website-sources to push the result into sirius-website.

See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4254 for context.